### PR TITLE
Fix choices in 01_00_ARC01_6

### DIFF
--- a/allscr/.gitignore
+++ b/allscr/.gitignore
@@ -1,2 +1,3 @@
 build/
+patched/
 *.mrg

--- a/allscr/generate_allscr.sh
+++ b/allscr/generate_allscr.sh
@@ -1,19 +1,30 @@
 #!/bin/bash
 set -e
 
-# Make build dir if not exists
+# Make build dirs if not exists
+mkdir -p patched/ || true
 mkdir -p build/ || true
 
+# Copy the retimed files into the build dir
+cp retimed/* patched/
+
+# Apply manual patches
+pushd patched
+for F in $(ls ../manual_tweaks/); do
+  patch -p0 < "../manual_tweaks/$F"
+done
+popd
+
 # Re-compress each of the script text files
-for F in $(ls decompressed); do
+for F in $(ls patched/); do
   echo -ne "Compressing $F\r"
   # Remove newlines
-  cat "retimed/$F" | tr -d '\n' > "build/$F"
+  cat "patched/$F" | tr -d '\n' > "build/$F"
   # Compress
   mzx_compress "build/$F" build/"`echo $F | sed 's/txt/bin/'`" &
 done
 wait
-echo "Finished ompressing script files"
+echo "Finished compressing script files       "
 
 # Add the binary archives into the build dir
 echo "Adding binary archives to build"

--- a/allscr/manual_tweaks/allscr.mrg_0024.patch
+++ b/allscr/manual_tweaks/allscr.mrg_0024.patch
@@ -1,0 +1,36 @@
+diff --git a/allscr/retimed/allscr.mrg_0024.txt b/allscr/retimed/allscr.mrg_0024.txt
+--- allscr.mrg_0024.txt
++++ allscr.mrg_0024.txt
+@@ -619,9 +619,9 @@ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(0);
+ _ZM08714($001919@n);
+-_WTTM(1,1);
+ _WKST(C847,eq,63);
+ _VPLY(B30_01_00_0011_1,03558);
++_WKAD(F823,1);
+ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(1);
+@@ -710,9 +710,9 @@ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(0);
+ _ZM08901($001923@n);
+-_WTTM(1,1);
+ _WKST(C847,eq,63);
+ _VPLY(B30_01_00_0012_0,0355b);
++_WKAD(F823,1);
+ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(1);
+@@ -752,9 +752,9 @@ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(0);
+ _ZM08a02($001926@n);
+-_WTTM(1,1);
+ _WKST(C847,eq,63);
+ _VPLY(B30_01_00_0012_0,0355b);
++_WKAD(F823,1);
+ _WKST(C847,eq,0);
+ _WKST(C859,eq,0);
+ _WNTY(1);

--- a/allscr/manual_tweaks/allscr.mrg_0077.patch
+++ b/allscr/manual_tweaks/allscr.mrg_0077.patch
@@ -1,7 +1,6 @@
 diff --git a/allscr/retimed/allscr.mrg_0077.txt b/allscr/retimed/allscr.mrg_0077.txt
-index 9fdabb1..a30e8d1 100644
---- a/allscr/retimed/allscr.mrg_0077.txt
-+++ b/allscr/retimed/allscr.mrg_0077.txt
+--- allscr.mrg_0077.txt
++++ allscr.mrg_0077.txt
 @@ -1845,7 +1845,7 @@ _WKAD(F823,1);
  _WKST(C847,eq,0);
  _WKST(C859,eq,0);


### PR DESCRIPTION
Seems to be a problem in this file where the choices are misaligned,
possibly related to the GOTOs in the script?

Since the `WTTM`s on the final glue section are not strictly needed,
remove them and put the `WKAD(F832, 1)` back, which seems to fix the
line accounting.