### PR TITLE
Bump DL to fix injection issue

### DIFF
--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Hakanaou/deepLuna
-          ref: v5.30
+          ref: v5.31
           path: deepluna
       - name: Lint
         run: |


### PR DESCRIPTION
Fixes bug where if you have a line that breaks such that it is precisely 55 chars on the final line _followed_ by a line that is glued and begins with a space, it will render the space instead of dropping it since the glued line starts on the next line down.