### PR TITLE
Fix ber00 / zap00 lines

### DIFF
--- a/.github/workflows/script_lint.yml
+++ b/.github/workflows/script_lint.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Hakanaou/deepLuna
-          ref: v5.49
+          ref: v5.50
           path: deepluna
       - name: Lint
         run: |

--- a/script/Arcueid/Day 10/10_00_ARC10_5D.txt
+++ b/script/Arcueid/Day 10/10_00_ARC10_5D.txt
@@ -1138,6 +1138,7 @@ All that's left in my mind is fear.
 [sha:f784c964cdc82e94975c3307726cf102abe3e22e]{
 -- Page 623, Offset 25930.
 -- 「[ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00]」
+%{no_break}
 "[ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00]"
 }
 [sha:dd923799bc38234f4bbe918d8f54b690304bd1a9]{

--- a/script/Arcueid/Day 10/10_00_ARC10_8_1.txt
+++ b/script/Arcueid/Day 10/10_00_ARC10_8_1.txt
@@ -112,6 +112,7 @@ Acting automatically, or perhaps out of some biological imperative,
 [sha:6c75bfa4a9bcd9e5c8044a73e17566bfccc6627e]{
 -- Page 857, Offset 26735.
 -- 『―――あああああ[ber00][ber00][ber00][ber00]―――！』
+%{no_break}
 "―――%{i}AAAAA%{/i}[ber00][ber00][ber00][ber00]―――!"
 }
 [sha:67a0a3b454f5194150ff62d2d4848405632d17b6]{

--- a/script/Arcueid/Day 13/13_00_ARC13_KRAKE.txt
+++ b/script/Arcueid/Day 13/13_00_ARC13_KRAKE.txt
@@ -355,6 +355,7 @@ She immediately switches gears, focusing on her new target.
 [sha:9d4ed8ece1a414b700d040ef67a891e9fd2b9726]{
 -- Page 281, Offset 32444.
 -- 「[ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00]―――」
+%{no_break}
 "[ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00][ber00]―――"
 }
 [sha:ea65c87c92bd14423aed74ab85204c17ad1a507c]{
@@ -535,6 +536,7 @@ If that left arm had been identical to its right, it would have made for a much 
 [sha:a7f59644ead6cdfe9f07076b057bd647a59bd61e]{
 -- Page 293, Offset 32478.
 -- 「[ber00][ber00][ber00][ber00][ber00][ber00]―――！」
+%{no_break}
 "[ber00][ber00][ber00][ber00][ber00][ber00]―――!"
 }
 [sha:9a8630179081ef520c0bf4bb74edf309522116e4]{

--- a/script/Arcueid/Day 2/02_00_ARC02_6.txt
+++ b/script/Arcueid/Day 2/02_00_ARC02_6.txt
@@ -413,6 +413,8 @@ But everything feels heavy, like I'm at the bottom of the ocean.
 [sha:919f0a5bcf49e493ff1947ffd1ebf50f85c509bf]{
 -- Page 360, Offset 3571.
 -- 『[zap00][zap00][zap00][zap00][zap00][zap00][zap00][zap00]』
+// Needs a no_break pragma otherwise we try and linebreak in the middle of the final command segment
+%{no_break}
 [zap00][zap00][zap00][zap00][zap00][zap00][zap00][zap00]
 }
 [sha:4a3ec6d0c86bb647dde3269d0b89bbf961fea432]{

--- a/script/Ciel/Day 5/05_01_CIEL05_3E.txt
+++ b/script/Ciel/Day 5/05_01_CIEL05_3E.txt
@@ -843,6 +843,7 @@ Each scripture she possesses is the embodiment of one of these causes,
 [sha:5480c6826fb3339134cd06c08a976caf9b4d82dd]{
 -- Page 629, Offset 12509.
 -- 「[ber00][ber00][ber00][ber00][ber00][ber00]――――――！」
+%{no_break}
 "[ber00][ber00][ber00][ber00][ber00][ber00]―――!"
 }
 [sha:eacadbf1b59fe2c071b1abc449465892b408c632]{


### PR DESCRIPTION
When updating the injection handling to support some of Noel's more impressive screams, I introduced a bug related to the ber00 and zap00 control codes - since they look like one really long word to the injector, it uses the new "scream too long" behaviour to start wrapping them as soon as they hit 55 chars, which breaks some of the codes on the longer occurrences. 

This patch adds a `%{no_break}` tag, which instructs deepluna to just not even bother trying to linebreak a given line. This fixes the tested scenes.