### PR TITLE
r1 feedback

### DIFF
--- a/script/Arcueid/Day 1/01_00_ARC01_9B.txt
+++ b/script/Arcueid/Day 1/01_00_ARC01_9B.txt
@@ -6,7 +6,7 @@ After dinner, I return to my room.
 [sha:26ed2e516730c7edf6472ff9306247944d4e2ef9]{
 -- Page 10027, Offset 2478.
 -- 時刻は９時半を回っていた。
-It's now 9:30.
+It's now 9:30 PM.
 }
 [sha:3857a766b9a8492604d51ffd9d5eacc69fe4e1e8]{
 -- Page 10027, Offset 2479.

--- a/script/Arcueid/Day 10/10_00_ARC10_5C.txt
+++ b/script/Arcueid/Day 10/10_00_ARC10_5C.txt
@@ -7,7 +7,7 @@ In the end, Arcueid makes me show her around the broadcasting room, fine arts ro
 [sha:788ff5af98ada052b561e9c2976d36f36c5beb30]{
 -- Page 10017, Offset 25565.
 -- 時刻は夜の７時半を過ぎたあたり。
-It's just past 7:30.
+It's just past 7:30 PM.
 }
 [sha:d68df26a7d0f1dc0b9f9b5ac27bd7fcc8add7a50]{
 -- Page 10017, Offset 25566.

--- a/script/Arcueid/Day 2/02_00_ARC02_1.txt
+++ b/script/Arcueid/Day 2/02_00_ARC02_1.txt
@@ -518,7 +518,7 @@ Chuckling, Kohaku-san clears the table.
 [sha:4833f48def3ff66f79fd0cc8b20f28483f342dbe]{
 -- Page 36, Offset 2694.
 -- 確かに時刻は７時20分、そろそろ登校の支度をしないと。
-It's 7:20. I should be getting ready for school.
+It's 7:20 AM. I should be getting ready for school.
 }
 [sha:c3c44209a8c7d406665bb8833016442a56018575]{
 -- Page 36, Offset 2695.

--- a/script/Arcueid/Day 2/02_00_ARC02_1C.txt
+++ b/script/Arcueid/Day 2/02_00_ARC02_1C.txt
@@ -1,7 +1,7 @@
 [sha:7cfe8c4884677aa07daef5ff4490071eab2a8fd6]{
 -- Page 10002, Offset 2837.
 -- 居間の時計は７時半を指している。
-The clock in the living room reads 7:30.
+The clock in the living room reads 7:30 AM.
 }
 [sha:ac9024a4708ffc76a5f7d4df7c29fa7ac3f50f99]{
 -- Page 10002, Offset 2838.

--- a/script/Arcueid/Day 2/02_00_ARC02_4.txt
+++ b/script/Arcueid/Day 2/02_00_ARC02_4.txt
@@ -241,7 +241,7 @@ I look at my phone.
 [sha:0e68ba5c338f01ca324fcd1ff24862acd8ac3d91]{
 -- Page 193, Offset 3112.
 -- 時計は無慈悲にも７時40分―――やばい、門限まであと20分しかない！
-The clock mercilessly reports that it's 7:40――crap, I only have twenty minutes left before curfew!
+The clock mercilessly reports that it's 7:40 PM――crap, I only have twenty minutes left before curfew!
 }
 [sha:2f523f69a71d12c9e96a3fa274640f1b67b7c84b]{
 -- Page 194, Offset 3113.

--- a/script/Arcueid/Day 4/04_00_ARC04_3.txt
+++ b/script/Arcueid/Day 4/04_00_ARC04_3.txt
@@ -79,7 +79,7 @@ As I approach the school, I see more and more people wearing school uniforms.
 [sha:7b5f4252e3ce354923b7b989b058817d6bc0c692]{
 -- Page 106, Offset 5825.
 -- 時刻は７時45分。
-The time is 7:45.
+The time is 7:45 AM.
 }
 [sha:60003e4a09341ade920bae6adf2e3b4112c538bd]{
 -- Page 106, Offset 5826.

--- a/script/Arcueid/Day 9/09_00_ARC09_2.txt
+++ b/script/Arcueid/Day 9/09_00_ARC09_2.txt
@@ -12,7 +12,7 @@ I still have plenty of things I need to think about,
 [sha:38021f55a71778179e0b145e6cd8f65b754b0af5]{
 -- Page 10004, Offset 21383.
 -- 時刻は７時半。
-The time is 7:30.
+The time is 7:30 AM.
 }
 [sha:d4d1a89f4cfa45297e86330f0a397413d79e0773]{
 -- Page 10004, Offset 21384.

--- a/script/Ciel/Day 8/08_01_CIEL08_1B.txt
+++ b/script/Ciel/Day 8/08_01_CIEL08_1B.txt
@@ -379,7 +379,7 @@ Now convinced, I stand up from the sofa.
 [sha:38021f55a71778179e0b145e6cd8f65b754b0af5]{
 -- Page 62, Offset 18415.
 -- 時刻は７時半。
-The time is 7:30.
+The time is 7:30 AM.
 }
 [sha:f500d73590a2148796606414a1c6b80bd2a0d4e1]{
 -- Page 62, Offset 18416.

--- a/script/Ciel/Day 9/09_01_CIEL09_1.txt
+++ b/script/Ciel/Day 9/09_01_CIEL09_1.txt
@@ -398,7 +398,7 @@ I spent too much time on breakfast.
 [sha:db59b8b0d863e219ecd04332c712a943f1de8783]{
 -- Page 29, Offset 22208.
 -- 時刻は午前７時半、俺も急がないと間に合わない。
-It's already 7:30, I'd better get a move on myself if I don't want to be late.
+It's already 7:30 AM, I'd better get a move on myself if I don't want to be late.
 }
 [sha:0c4db357c4364ce50df3f8dc43d69e421c14a024]{
 -- Page 30, Offset 22209.


### PR DESCRIPTION
Add 'AM' or 'PM' after the time for clarity and consistency. I think this should be all of it. In cases where the time of day was in the sentence, like 'morning' in Offset 14861, I didn't add it